### PR TITLE
Adding dual license information to include MIT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ console.log(expand(template, {
 ```
 
 ## License
-All code, unless stated otherwise, is licensed under the [`WTFPL`](http://www.wtfpl.net/txt/copying/).
+All code, unless stated otherwise, is dual-licensed under [`WTFPL`](http://www.wtfpl.net/txt/copying/) and [`MIT`](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Hey @ralphtheninja, any chance we can move this to a dual license under both WTFPL and MIT?
