### PR TITLE
Ensure MIT is included in SPDX license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "replace"
   ],
   "author": "LM <ralphtheninja@riseup.net>",
-  "license": "WTFPL",
+  "license": "(MIT or WTFPL)",
   "dependencies": {},
   "devDependencies": {
     "standard": "^12.0.0",


### PR DESCRIPTION
Hello, this small change allows automated tooling to detect/verify the dual licensing of this module.