### PR TITLE
Use strict upper case syntax for SPDX license

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "replace"
   ],
   "author": "LM <ralphtheninja@riseup.net>",
-  "license": "(MIT or WTFPL)",
+  "license": "(MIT OR WTFPL)",
   "dependencies": {},
   "devDependencies": {
     "standard": "^12.0.0",


### PR DESCRIPTION
I should have got this right first time, sorry for the extra maintenance overhead.